### PR TITLE
Don't handle mousepressed if you're not connected.

### DIFF
--- a/user.lua
+++ b/user.lua
@@ -145,6 +145,7 @@ end
 
 
 function User:mousepressed(m_x, m_y, button)
+    if(not self.player) then return end
     button = tostring(button)
     if not self.mouse_updates then self.mouse_updates = {} end
 


### PR DESCRIPTION
Avoid a crash on startup.